### PR TITLE
Use SQLite for persistent video store

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,6 @@ This project provides a simple REST API for generating videos through HeyGen and
    ```
 
 The API will be available at `http://localhost:8000`.
+Video metadata is stored in a local `SQLite` database (`videos.db`) created automatically in the project directory.
 
 Refer to `openapi.yaml` for the API specification.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+SQLAlchemy

--- a/server.py
+++ b/server.py
@@ -1,8 +1,36 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from pydantic import BaseModel
 from uuid import uuid4
+from sqlalchemy import Column, String, Text, create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker, Session
+
+engine = create_engine(
+    "sqlite:///./videos.db", connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
 
 app = FastAPI(title="HeyGen MCP Adapter API")
+
+
+class Video(Base):
+    __tablename__ = "videos"
+
+    video_id = Column(String, primary_key=True, index=True)
+    status = Column(String, default="PENDING")
+    video_url = Column(String, nullable=True)
+    error_message = Column(Text, nullable=True)
+
+
+Base.metadata.create_all(bind=engine)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
 
 
 class VideoRequest(BaseModel):
@@ -18,25 +46,25 @@ class VideoStatus(BaseModel):
     error_message: str | None = None
 
 
-video_store: dict[str, dict] = {}
-
-
 @app.post("/video/generate", status_code=202)
-async def generate_video(req: VideoRequest):
+async def generate_video(req: VideoRequest, db: Session = Depends(get_db)):
     video_id = f"video_{uuid4().hex}"
-    video_store[video_id] = {"status": "PENDING"}
+    video = Video(video_id=video_id, status="PENDING")
+    db.add(video)
+    db.commit()
+    db.refresh(video)
     # TODO: integrate with HeyGen API for actual video generation
-    return {"video_id": video_id, "status": "PENDING"}
+    return {"video_id": video_id, "status": video.status}
 
 
 @app.get("/video/{video_id}/status", response_model=VideoStatus)
-async def get_video_status(video_id: str):
-    data = video_store.get(video_id)
-    if data is None:
+async def get_video_status(video_id: str, db: Session = Depends(get_db)):
+    video = db.get(Video, video_id)
+    if video is None:
         raise HTTPException(status_code=404, detail="Video ID not found.")
     return {
-        "video_id": video_id,
-        "status": data.get("status", "PENDING"),
-        "video_url": data.get("video_url"),
-        "error_message": data.get("error_message"),
+        "video_id": video.video_id,
+        "status": video.status,
+        "video_url": video.video_url,
+        "error_message": video.error_message,
     }


### PR DESCRIPTION
## Summary
- persist video metadata in SQLite
- add SQLAlchemy video model and session management
- update API handlers to use the database
- document SQLite usage
- add SQLAlchemy to requirements

## Testing
- `python -m py_compile server.py`
