### PR TITLE
Implement token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,14 @@ This project provides a simple REST API for generating videos through HeyGen and
 The API will be available at `http://localhost:8000`.
 
 Refer to `openapi.yaml` for the API specification.
+
+## Authentication
+
+Set the `API_TOKEN` environment variable to define the token expected by the
+server (defaults to `dev-token`). Requests to `/video/generate` and
+`/video/{video_id}/status` must include this token using the `Authorization`
+header:
+
+```bash
+curl -H "Authorization: Bearer $API_TOKEN" http://localhost:8000/video/generate
+```

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7,11 +7,20 @@ servers:
   - url: http://localhost:3001 # Example URL, will be replaced by actual deployment URL
     description: Local development server
 
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
 paths:
   /video/generate:
     post:
       summary: Generate a new video
       description: Submits a script to HeyGen for video generation using a specified avatar and voice.
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -60,6 +69,8 @@ paths:
     get:
       summary: Get video status
       description: Retrieves the current status of a video generation task and the video URL if available.
+      security:
+        - bearerAuth: []
       parameters:
         - name: video_id
           in: path


### PR DESCRIPTION
## Summary
- add token-based auth dependency
- require token for generate/status endpoints
- document token setup in README
- describe bearer auth scheme in openapi spec

## Testing
- `python -m py_compile server.py`