### PR TITLE
Add pytest-based test suite

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+pytest
+httpx

--- a/server.py
+++ b/server.py
@@ -1,6 +1,23 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from uuid import uuid4
+import httpx
+
+
+async def create_video_with_heygen(req: "VideoRequest") -> dict:
+    """Send the video generation request to HeyGen.
+
+    This function is a thin wrapper around the HeyGen API. It will be mocked in
+    tests. In a real implementation it would authenticate and send the request
+    to the HeyGen service.
+    """
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            "https://api.heygen.com/v1/videos", json=req.dict()
+        )
+        response.raise_for_status()
+        return response.json()
 
 app = FastAPI(title="HeyGen MCP Adapter API")
 
@@ -25,8 +42,14 @@ video_store: dict[str, dict] = {}
 async def generate_video(req: VideoRequest):
     video_id = f"video_{uuid4().hex}"
     video_store[video_id] = {"status": "PENDING"}
-    # TODO: integrate with HeyGen API for actual video generation
-    return {"video_id": video_id, "status": "PENDING"}
+    try:
+        data = await create_video_with_heygen(req)
+        video_store[video_id].update(
+            {"status": "COMPLETE", "video_url": data.get("video_url")}
+        )
+    except Exception as exc:  # pragma: no cover - defensive programming
+        video_store[video_id].update({"status": "ERROR", "error_message": str(exc)})
+    return {"video_id": video_id, "status": video_store[video_id]["status"]}
 
 
 @app.get("/video/{video_id}/status", response_model=VideoStatus)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,60 @@
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from server import app, video_store
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def clear_store():
+    video_store.clear()
+    yield
+    video_store.clear()
+
+
+def test_generate_and_status_success(monkeypatch):
+    async def mock_create(req):
+        return {"video_url": "http://example.com/out.mp4"}
+
+    monkeypatch.setattr("server.create_video_with_heygen", mock_create)
+
+    payload = {"script_text": "hello", "avatar_id": "a1", "voice_id": "v1"}
+    resp = client.post("/video/generate", json=payload)
+    assert resp.status_code == 202
+    body = resp.json()
+    video_id = body["video_id"]
+    assert body["status"] == "COMPLETE"
+
+    status_resp = client.get(f"/video/{video_id}/status")
+    assert status_resp.status_code == 200
+    status_body = status_resp.json()
+    assert status_body["status"] == "COMPLETE"
+    assert status_body["video_url"] == "http://example.com/out.mp4"
+    assert status_body["error_message"] is None
+
+
+def test_generate_error(monkeypatch):
+    async def mock_create(req):
+        raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr("server.create_video_with_heygen", mock_create)
+
+    payload = {"script_text": "bad", "avatar_id": "a1", "voice_id": "v1"}
+    resp = client.post("/video/generate", json=payload)
+    assert resp.status_code == 202
+    body = resp.json()
+    video_id = body["video_id"]
+    assert body["status"] == "ERROR"
+
+    status_resp = client.get(f"/video/{video_id}/status")
+    assert status_resp.status_code == 200
+    status_body = status_resp.json()
+    assert status_body["status"] == "ERROR"
+    assert status_body["error_message"] == "boom"
+
+
+def test_unknown_video_status():
+    resp = client.get("/video/does-not-exist/status")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- add HTTPX-based HeyGen client
- include pytest and httpx in dependencies
- create tests for video generation endpoints

## Testing
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*
- `pytest -q` *(fails: command not found)*